### PR TITLE
Use snprintf for string padding

### DIFF
--- a/cmddump.c
+++ b/cmddump.c
@@ -76,9 +76,7 @@ main(int argc, char* argv[])
       isam = strtol(optarg, NULL, 0);
       break;
     case 'p':
-      strncpy(pdsbuf, optarg, 8);
-      pdsbuf[8] = '\000';
-      strncat(pdsbuf, "        ", 8 - strlen(pdsbuf));
+      snprintf(pdsbuf, sizeof(pdsbuf), "%s%8s", optarg, "");
       pds = pdsbuf;
       break;
     case 'x':


### PR DESCRIPTION
Recent gcc versions emit new warnings about string truncation:

cmddump.c:78:7: error: 'strncat' output truncated copying between 0 and 8 bytes from a string of length 8 [-Werror=stringop-truncation]
       strncat(pdsbuf, "        ", 8 - strlen(pdsbuf));
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This can be prevented by using snprintf for string padding.

Bug-Debian: https://bugs.debian.org/905029