### PR TITLE
Remove unused argument

### DIFF
--- a/trs_cassette.c
+++ b/trs_cassette.c
@@ -628,7 +628,7 @@ static int assert_state(int state)
       cassette_format = DIRECT_FORMAT;
       strcpy(cassette_filename, DSP_FILENAME);
     } else {
-      get_control(state);
+      get_control();
     }
     if (cassette_format == DIRECT_FORMAT) {
 #if !HAVE_OSS


### PR DESCRIPTION
`clang` shows this warning:
```C
trs_cassette.c:631:24: warning: too many arguments in call to 'get_control'
      get_control(state);
      ~~~~~~~~~~~      ^
```