### PR TITLE
Fix assigning values to alternate register set

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -746,7 +746,7 @@ void debug_shell(void)
 		char regname[MAXLINE];
 		int addr, value;
 
-		if(sscanf(input, "%*s $%[a-zA-Z] = %x", regname, &value) == 2)
+		if(sscanf(input, "%*s $%[a-zA-Z'] = %x", regname, &value) == 2)
 		{
 		    if(!strcasecmp(regname, "a")) {
 			REG_A = value;


### PR DESCRIPTION
The alternate register set (AF', BC', etc) could not be modified because the prime character ' was not part of the character set.